### PR TITLE
Feature/61: AndQuery(무한스크롤) 구현 및 And 엔티티, 매퍼 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,10 +2,21 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.26/8f8cf0372abf564913e9796623aac4c8ea44025a/lombok-1.18.26.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-apt/5.0.0/d48657412f2b96d787bbe5ae393e33815c94b4d0/querydsl-apt-5.0.0-jakarta.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.annotation/jakarta.annotation-api/2.1.1/48b9bda22b091b1f48b13af03fe36db3be6e1ae3/jakarta.annotation-api-2.1.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.persistence/jakarta.persistence-api/3.1.0/66901fa1c373c6aff65c13791cc11da72060a8d6/jakarta.persistence-api-3.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-codegen/5.0.0/d690e92300f528e4161307b286f76aeaf348e2fb/querydsl-codegen-5.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/querydsl-core/5.0.0/7a469f78b7a89bae429f17766fb92687d0ab9e5b/querydsl-core-5.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.querydsl/codegen-utils/5.0.0/ff8a2ebbc3a317715de0ce2856c2024534d18a1a/codegen-utils-5.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/io.github.classgraph/classgraph/4.8.108/1c175d4ce7a1fa67463bad731f37f1a284dab790/classgraph-4.8.108.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.mysema.commons/mysema-commons-lang/0.2.4/d09c8489d54251a6c22fbce804bdd4a070557317/mysema-commons-lang-0.2.4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jdt/ecj/3.26.0/4837be609a3368a0f7e7cf0dc1bdbc7fe94993de/ecj-3.26.0.jar" />
         </processorPath>
         <module name="andcrowd.main" />
       </profile>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/AndCrowd-Backend.iml" filepath="$PROJECT_DIR$/.idea/AndCrowd-Backend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/andcrowd.test.iml" filepath="$PROJECT_DIR$/.idea/modules/andcrowd.test.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/andcrowd.test.iml
+++ b/.idea/modules/andcrowd.test.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../andcrowd/src/test" dumb="true">
+      <sourceFolder url="file://$MODULE_DIR$/../../andcrowd/src/test/resources" type="java-test-resource" />
+    </content>
+  </component>
+</module>

--- a/andcrowd/build.gradle
+++ b/andcrowd/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.2'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.fiveis'
@@ -34,8 +35,32 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.0'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'javax.persistence:javax.persistence-api:2.2'
+	// Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// queryDSL 추가 : QueryDSL 빌드 옵션
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/config/JPAConfig.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/config/JPAConfig.java
@@ -1,0 +1,26 @@
+//package com.fiveis.andcrowd.config;
+//
+//import com.querydsl.jpa.impl.JPAQueryFactory;
+//import jakarta.persistence.EntityManager;
+//import jakarta.persistence.PersistenceContext;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+//import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+//
+//@Configuration
+//@EnableJpaAuditing
+//@EnableJpaRepositories(basePackages = "com.fiveis.andcrowd")
+//public class JPAConfig {
+//
+//    @PersistenceContext
+//    private EntityManager entityManager;
+//
+//    @Bean
+//    public JPAQueryFactory queryFactory() {
+//        return new JPAQueryFactory(entityManager);
+//    }
+//
+//
+//
+//}

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/entity/and/And.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/entity/and/And.java
@@ -2,6 +2,7 @@ package com.fiveis.andcrowd.entity.and;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -28,7 +29,7 @@ public class And {
     @Column(nullable = false)
     private int andCategoryId;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private int crowdId;
 
     @Column(nullable = false)
@@ -56,29 +57,35 @@ public class And {
 
     private String andImg5;
 
+    @Column(nullable = true, columnDefinition = "datetime default CURRENT_TIMESTAMP")
     private LocalDateTime publishedAt;
 
+    @Column(nullable = true, columnDefinition = "datetime default CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
-    @Column(nullable = false)
+    @ColumnDefault("0")
     private int andLikeCount;
 
-    @Column(nullable = false)
+    @ColumnDefault("0")
     private int andViewCount;
 
-    @Column(nullable = false)
+    @ColumnDefault("1")
     private int andStatus; // 0 : 모집 중, 1 : 심사 중, 2 : 반려, 3: 모집 종료
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private int adId;
 
-    @Column(nullable = false)
-    private boolean isDeleted = Boolean.FALSE;
+    @ColumnDefault("false")
+    private boolean isDeleted;
 
     @PrePersist
     public void setDefaultValue(){
         this.publishedAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
+        this.isDeleted = false;
+        this.andLikeCount = 0;
+        this.andViewCount = 0;
+        this.andStatus = 1; // 처음 작성시 자동으로 심사 중인 1로 표기
     }
 
     @PreUpdate

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndJPARepository.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndJPARepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface AndJPARepository extends JpaRepository<And, Integer> {
+public interface AndJPARepository extends JpaRepository<And, Integer>, AndQueryRepository {
     List<AndDTO.FindAllByUserId> findAllByUserId(int userId);
 //    List<AndDTO.Find> findAllByIsDeletedFalse();
     List<And> findAllByIsDeletedFalse();

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndQueryRepository.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndQueryRepository.java
@@ -1,0 +1,13 @@
+package com.fiveis.andcrowd.repository.and;
+
+import com.fiveis.andcrowd.dto.and.AndDTO;
+import com.fiveis.andcrowd.entity.and.And;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AndQueryRepository {
+    Slice<AndDTO.Find> findAllByCategoryAndStatusAndSort(
+            Integer categoryId, Integer andStatus, String sortField, String sortOrder, Pageable pageable);
+}

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndQueryRepositoryImpl.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndQueryRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.fiveis.andcrowd.repository.and;
+
+import com.fiveis.andcrowd.dto.and.AndDTO;
+import com.fiveis.andcrowd.entity.and.And;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+
+import java.util.List;
+
+import static com.fiveis.andcrowd.entity.and.QAnd.and;
+
+@Repository
+public class AndQueryRepositoryImpl implements AndQueryRepository{
+
+    private final EntityManager em;
+    private final JPAQueryFactory query; // QueryDSL (JPA 쿼리)
+
+    public AndQueryRepositoryImpl(EntityManager em) {
+        this.em = em;
+        this.query = new JPAQueryFactory(em); // 주입된 EntityManager를 사용하여 JPAQueryFactory 인스턴스 생성 및 저장
+    }
+
+    public Slice<AndDTO.Find> findAllByCategoryAndStatusAndSort(
+            Integer categoryId, Integer andStatus, String sortField, String sortOrder, Pageable pageable) {
+
+        List<AndDTO.Find> results = query
+                .select(Projections.fields(AndDTO.Find.class,
+                        and.andId,
+                        and.userId,
+                        and.andCategoryId,
+                        and.crowdId,
+                        and.andTitle,
+                        and.andHeaderImg,
+                        and.andContent,
+                        and.andEndDate,
+                        and.needNumMem,
+                        and.andImg1,
+                        and.andImg2,
+                        and.andImg3,
+                        and.andImg4,
+                        and.andImg5,
+                        and.publishedAt,
+                        and.updatedAt,
+                        and.andLikeCount,
+                        and.andViewCount,
+                        and.andStatus,
+                        and.adId,
+                        and.isDeleted
+                ))
+                .from(and)
+                .where(
+                        eqCategory(categoryId),
+                        eqAndStatus(andStatus)
+                )
+                .orderBy(buildOrderSpecifier(sortField, sortOrder))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = results.size() > pageable.getPageSize();
+        if (hasNext) {
+            results.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private BooleanExpression eqCategory(Integer categoryId) {
+        return categoryId != null ? and.andCategoryId.eq(categoryId) : null;
+    }
+
+    private BooleanExpression eqAndStatus(Integer andStatus) {
+        return andStatus != null ? and.andStatus.eq(andStatus) : null;
+    }
+
+    private OrderSpecifier<?> buildOrderSpecifier(String sortField, String sortOrder) {
+        if (StringUtils.isEmpty(sortField) || StringUtils.isEmpty(sortOrder)) {
+            return and.publishedAt.desc();
+        }
+
+        OrderSpecifier<?> orderSpecifier;
+        switch (sortField) {
+            case "publishedAt":
+                orderSpecifier = sortOrder.equalsIgnoreCase("asc") ? and.publishedAt.asc() : and.publishedAt.desc();
+                break;
+            case "andEndDate":
+                orderSpecifier = sortOrder.equalsIgnoreCase("asc") ? and.andEndDate.asc() : and.andEndDate.desc();
+                break;
+            case "andLikeCount":
+                orderSpecifier = sortOrder.equalsIgnoreCase("asc") ? and.andLikeCount.asc() : and.andLikeCount.desc();
+                break;
+            case "andViewCount":
+                orderSpecifier = sortOrder.equalsIgnoreCase("asc") ? and.andViewCount.asc() : and.andViewCount.desc();
+                break;
+            default:
+                orderSpecifier = and.publishedAt.desc();
+        }
+        return orderSpecifier;
+    }
+}

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndQueryService.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndQueryService.java
@@ -1,0 +1,13 @@
+package com.fiveis.andcrowd.service.and;
+
+import com.fiveis.andcrowd.dto.and.AndDTO;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface AndQueryService {
+    Slice<AndDTO.Find> findAllByCategoryAndStatusAndSort(
+            Integer categoryId, Integer andStatus, String sortField, String sortOrder, Pageable pageable);
+
+}

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndQueryServiceImpl.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.fiveis.andcrowd.service.and;
+
+import com.fiveis.andcrowd.dto.and.AndDTO;
+import com.fiveis.andcrowd.repository.and.AndQueryRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AndQueryServiceImpl implements AndQueryService{
+    private final AndQueryRepository andQueryRepository;
+
+    public AndQueryServiceImpl(AndQueryRepository andQueryRepository) {
+        this.andQueryRepository = andQueryRepository;
+    }
+    
+    @Override
+    public Slice<AndDTO.Find> findAllByCategoryAndStatusAndSort(Integer categoryId, Integer andStatus, String sortField, String sortOrder, Pageable pageable) {
+        return andQueryRepository.findAllByCategoryAndStatusAndSort(categoryId, andStatus, sortField, sortOrder, pageable);
+    }
+}

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndQueryServiceImpl.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.fiveis.andcrowd.service.and;
 
 import com.fiveis.andcrowd.dto.and.AndDTO;
 import com.fiveis.andcrowd.repository.and.AndQueryRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -10,10 +11,10 @@ import org.springframework.stereotype.Service;
 public class AndQueryServiceImpl implements AndQueryService{
     private final AndQueryRepository andQueryRepository;
 
-    public AndQueryServiceImpl(AndQueryRepository andQueryRepository) {
+    public AndQueryServiceImpl(@Qualifier("andQueryRepositoryImpl") AndQueryRepository andQueryRepository) {
         this.andQueryRepository = andQueryRepository;
     }
-    
+
     @Override
     public Slice<AndDTO.Find> findAllByCategoryAndStatusAndSort(Integer categoryId, Integer andStatus, String sortField, String sortOrder, Pageable pageable) {
         return andQueryRepository.findAllByCategoryAndStatusAndSort(categoryId, andStatus, sortField, sortOrder, pageable);

--- a/andcrowd/src/main/resources/mybatis/mapper/and/AndDynamicMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/AndDynamicMapper.xml
@@ -5,7 +5,7 @@
 <mapper namespace="com.fiveis.andcrowd.repository.and.AndDynamicRepository">
 
     <insert id="createDynamicAndQnaTable">
-        CREATE TABLE and_qna_#{and_id}(
+        CREATE TABLE IF NOT EXISTS and_qna_#{and_id}(
           and_qna_id INT AUTO_INCREMENT PRIMARY KEY ,
           and_id INT NOT NULL ,
           user_id INT NOT NULL ,
@@ -18,7 +18,7 @@
     </insert>
 
     <insert id="createDynamicAndQnaReplyTable">
-        CREATE TABLE and_qna_reply_#{and_id}(
+        CREATE TABLE IF NOT EXISTS and_qna_reply_#{and_id}(
           and_reply_id INT AUTO_INCREMENT PRIMARY KEY ,
           and_qna_id INT NOT NULL ,
           and_id INT NOT NULL,
@@ -31,7 +31,7 @@
     </insert>
 
     <insert id="createDynamicAndRoleTable">
-        CREATE TABLE and_role_#{and_id}(
+        CREATE TABLE IF NOT EXISTS and_role_#{and_id}(
             and_role_id INT AUTO_INCREMENT PRIMARY KEY ,
             and_id INT NOT NULL ,
             and_role VARCHAR(2000) NOT NULL ,
@@ -41,7 +41,7 @@
     </insert>
 
     <insert id="createDynamicAndApplicantTable">
-        CREATE TABLE and_applicant_#{and_id}(
+        CREATE TABLE IF NOT EXISTS and_applicant_#{and_id}(
            and_apply_id INT AUTO_INCREMENT PRIMARY KEY ,
            and_id INT NOT NULL ,
            user_id INT NOT NULL ,
@@ -52,7 +52,7 @@
     </insert>
 
     <insert id="createDynamicAndBoardTable">
-        CREATE TABLE and_board_#{and_id} (
+        CREATE TABLE IF NOT EXISTS and_board_#{and_id} (
         and_board_id INT AUTO_INCREMENT PRIMARY KEY ,
         and_id INT NOT NULL,
         user_id INT NOT NULL,
@@ -68,7 +68,7 @@
     </insert>
 
     <insert id="createDynamicAndMemberTable">
-        CREATE TABLE and_member_#{and_id} (
+        CREATE TABLE IF NOT EXISTS and_member_#{and_id} (
         member_id INT AUTO_INCREMENT PRIMARY KEY ,
         and_id INT NOT NULL,
         user_id INT NOT NULL,

--- a/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndApplicantMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndApplicantMapper.xml
@@ -70,7 +70,7 @@
 
 
     <insert id="save" parameterType="com.fiveis.andcrowd.dto.and.DynamicAndApplicantDTO$Update">
-        INSERT INTO and_applicant_#{andId} (and_apply_id, and_id, user_id, and_role_id, and_apply_content, and_apply_status, is_deleted)
+        INSERT IGNORE INTO and_applicant_#{andId} (and_apply_id, and_id, user_id, and_role_id, and_apply_content, and_apply_status, is_deleted)
         VALUES (#{andApplyId, jdbcType=INTEGER}, #{andId, jdbcType=INTEGER}, #{userId, jdbcType=INTEGER}, #{andRoleId, jdbcType=INTEGER}, #{andApplyContent, jdbcType=VARCHAR}, #{andApplyStatus, jdbcType=INTEGER}, #{isDeleted, jdbcType=BIT})
     </insert>
 
@@ -105,7 +105,7 @@
     </update>
 
     <insert id="insertTestData">
-        INSERT INTO and_applicant_123 (and_apply_id, and_id, user_id, and_role_id, and_apply_content)
+        INSERT IGNORE INTO and_applicant_123 (and_apply_id, and_id, user_id, and_role_id, and_apply_content)
         VALUES
             (1, 123, 11, 3, '신청서 내용 1'),
             (2, 123, 12, 2, '신청서 내용 2'),

--- a/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndBoardMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndBoardMapper.xml
@@ -80,7 +80,7 @@
         DROP TABLE and_board_1111;
     </update>
     <insert id="insertTestData">
-        INSERT INTO and_board_1111 (and_id, user_id, and_board_title, and_board_content)
+        INSERT IGNORE INTO and_board_1111 (and_id, user_id, and_board_title, and_board_content)
         VALUES
             (1111, 1, 'Board Title 1', 'Board Content 1'),
             (1111, 2, 'Board Title 2', 'Board Content 2'),

--- a/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndMemberMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndMemberMapper.xml
@@ -48,7 +48,7 @@
     </update>
 
     <insert id="insertTestData">
-        INSERT INTO and_member_1111 (and_id, user_id)
+        INSERT IGNORE INTO and_member_1111 (and_id, user_id)
         VALUES
             (1111, 1),
             (1111, 2),

--- a/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndQnaMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndQnaMapper.xml
@@ -81,7 +81,7 @@
     </update>
 
     <insert id="insertTestData">
-        INSERT INTO and_qna_123 (and_id, user_id, and_qna_title, and_qna_content)
+        INSERT IGNORE INTO and_qna_123 (and_id, user_id, and_qna_title, and_qna_content)
         VALUES
             (123, 1, 'QnA Title 1', 'QnA Content 1'),
             (123, 2, 'QnA Title 2', 'QnA Content 2'),

--- a/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndQnaReplyMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndQnaReplyMapper.xml
@@ -106,7 +106,7 @@
     </update>
 
     <insert id="insertTestData">
-        INSERT INTO and_qna_reply_123 (and_reply_id, and_qna_id, and_id, user_id, and_reply_content)
+        INSERT IGNORE INTO and_qna_reply_123 (and_reply_id, and_qna_id, and_id, user_id, and_reply_content)
         VALUES
             (1, 1, 123, 1, 'QnA Reply Content 1'),
             (2, 2, 123, 2, 'QnA Reply Content 2'),

--- a/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndRoleMapper.xml
+++ b/andcrowd/src/main/resources/mybatis/mapper/and/DynamicAndRoleMapper.xml
@@ -70,7 +70,7 @@
     </update>
 
     <insert id="insertTestData">
-        INSERT INTO and_role_123 (and_role_id, and_id, and_role, and_role_limit)
+        INSERT IGNORE INTO and_role_123 (and_role_id, and_id, and_role, and_role_limit)
         VALUES
             (1, 123, '역할 1', 10),
             (2, 123, '역할 2', 20),

--- a/andcrowd/src/test/java/com/fiveis/andcrowd/repository/and/AndJPARepositoryTest.java
+++ b/andcrowd/src/test/java/com/fiveis/andcrowd/repository/and/AndJPARepositoryTest.java
@@ -1,6 +1,6 @@
 package com.fiveis.andcrowd.repository.and;
 import com.fiveis.andcrowd.entity.and.And;
-import com.fiveis.andcrowd.repository.and.AndJPARepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,35 +11,51 @@ import java.time.LocalDateTime;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-public class AndJPARepositoryDeleteTest {
+public class AndJPARepositoryTest {
 
     @Autowired
     private AndJPARepository andRepository;
-
     @Test
-    @Transactional
-    public void testSoftDeleteById() {
+    @BeforeEach
+    public void saveTest(){
+        // Given
+
+        // When
         // Given
         And newAnd = And.builder()
-                .andId(1)
                 .userId(1)
                 .andCategoryId(1)
-                .crowdId(1)
                 .andTitle("Test Title")
                 .andHeaderImg("header.jpg")
                 .andContent("Test Content")
                 .andEndDate(LocalDateTime.now().plusDays(7))
                 .needNumMem(5)
-                .andLikeCount(0)
-                .andViewCount(0)
-                .andStatus(0)
-                .adId(1)
                 .build();
 
         andRepository.save(newAnd);
+
+        // Then
+    }
+
+    @Test
+    @Transactional
+    public void testSoftDeleteById() {
+        // Given
+        And newAnd2 = And.builder()
+                .userId(3)
+                .andCategoryId(5)
+                .crowdId(1)
+                .andTitle("Test Title2")
+                .andHeaderImg("header.jpg2")
+                .andContent("Test Content2")
+                .andEndDate(LocalDateTime.now().plusDays(10))
+                .needNumMem(5)
+                .build();
+
+        andRepository.save(newAnd2);
         andRepository.flush();
 
-        int andIdToDelete = newAnd.getAndId();
+        int andIdToDelete = newAnd2.getAndId();
 
         // When
         andRepository.deleteById(andIdToDelete);

--- a/andcrowd/src/test/java/com/fiveis/andcrowd/repository/and/AndQueryRepositoryTest.java
+++ b/andcrowd/src/test/java/com/fiveis/andcrowd/repository/and/AndQueryRepositoryTest.java
@@ -1,0 +1,113 @@
+package com.fiveis.andcrowd.repository.and;
+
+import com.fiveis.andcrowd.dto.and.AndDTO;
+import com.fiveis.andcrowd.entity.and.And;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+
+@SpringBootTest
+public class AndQueryRepositoryTest {
+
+    @Autowired
+    @Qualifier("andQueryRepositoryImpl")
+    private AndQueryRepository andQueryRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @BeforeEach
+    public void setup() throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            ClassPathResource scriptResource = new ClassPathResource("/dummy_data.sql");
+            ScriptUtils.executeSqlScript(connection, scriptResource);
+        }
+    }
+
+    @AfterEach
+    public void cleanup() throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            ClassPathResource scriptResource = new ClassPathResource("/drop_dummy_data.sql");
+            ScriptUtils.executeSqlScript(connection, scriptResource);
+        }
+    }
+
+    @Test
+    public void testInfiniteScroll() {
+        // given
+        int categoryId = 1;
+        int andStatus = 0;
+        String sortField = "publishedAt";
+        String sortOrder = "desc";
+        int pageSize = 2;
+
+        int pageNumber = 0;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+
+        // when
+        Slice<AndDTO.Find> result = andQueryRepository.findAllByCategoryAndStatusAndSort(
+                categoryId, andStatus, sortField, sortOrder, pageable);
+
+        while (result.hasContent()) {
+            for (AndDTO.Find andDTO : result.getContent()) {
+                System.out.println(andDTO.toString());
+            }
+
+            pageNumber++;
+            pageable = PageRequest.of(pageNumber, pageSize);
+            result = andQueryRepository.findAllByCategoryAndStatusAndSort(
+                    categoryId, andStatus, sortField, sortOrder, pageable);
+        }
+    }
+
+    @Test
+    @DisplayName("No-Offset 방식을 사용하면 lastStoreId값 -1 부터 page size 만큼 가져옴")
+    public void testFindAll() {
+        // given
+        Slice<AndDTO.Find> result = andQueryRepository.findAllByCategoryAndStatusAndSort(1, 0, "andEndDate", "asc", PageRequest.ofSize(3));
+
+        // when
+        int first = result.getContent().get(0).getAndId();
+        int last = result.getContent().get(2).getAndId();
+
+        // then
+        Assertions.assertThat(first).isEqualTo(1);
+        Assertions.assertThat(last).isEqualTo(7);
+
+    }
+
+    @Test
+    @DisplayName("마지막 페이지에서는 isLast가 true, 마지막이 아니면 isLast가 false")
+    void checkLast()
+    {
+        // Given
+        Slice<AndDTO.Find> getLastPage = andQueryRepository.findAllByCategoryAndStatusAndSort(
+                1, 0, "andEndDate", "asc", PageRequest.ofSize(3));
+        Slice<AndDTO.Find> getMiddlePage = andQueryRepository.findAllByCategoryAndStatusAndSort(
+                1, 0, "andEndDate", "asc", PageRequest.ofSize(2));
+
+        // When
+        boolean isLastPage = getLastPage.isLast();
+        boolean isNotLastPage = getMiddlePage.isLast();
+
+        // Then
+        Assertions.assertThat(isLastPage).isTrue();
+        Assertions.assertThat(isNotLastPage).isFalse();
+    }
+
+}

--- a/andcrowd/src/test/resources/drop_dummy_data.sql
+++ b/andcrowd/src/test/resources/drop_dummy_data.sql
@@ -1,0 +1,25 @@
+DROP TABLE and_table;
+create table and_table (
+                           and_id integer not null auto_increment,
+                           ad_id integer not null,
+                           and_category_id integer not null,
+                           and_content varchar(255) not null,
+                           and_end_date datetime(6) not null,
+                           and_header_img varchar(255) not null,
+                           and_img1 varchar(255),
+                           and_img2 varchar(255),
+                           and_img3 varchar(255),
+                           and_img4 varchar(255),
+                           and_img5 varchar(255),
+                           and_like_count integer not null,
+                           and_status integer not null,
+                           and_title varchar(255) not null,
+                           and_view_count integer not null,
+                           crowd_id integer not null,
+                           is_deleted bit not null,
+                           need_num_mem integer not null,
+                           published_at datetime(6),
+                           updated_at datetime(6),
+                           user_id integer not null,
+                           primary key (and_id)
+)

--- a/andcrowd/src/test/resources/dummy_data.sql
+++ b/andcrowd/src/test/resources/dummy_data.sql
@@ -1,0 +1,12 @@
+INSERT INTO and_table (and_id, user_id, and_category_id, crowd_id, and_title, and_header_img, and_content, and_end_date, need_num_mem, and_img1, and_img2, and_img3, and_img4, and_img5, published_at, updated_at, and_like_count, and_view_count, and_status, ad_id, is_deleted)
+VALUES
+    (NULL, 1, 1, 321, "andtitle1", "headerimgdir1", "andcontent1", '2023-08-16 09:45:00', 2, null, null, null, null, null, now(), now(), 10, 15, 0, 0, false),
+    (NULL, 10, 4, 323, "andtitle2", "headerimgdir2", "andcontent2", '2023-08-17 10:30:00', 3, null, null, null, null, null, now(), now(), 8, 20, 1, 0, false),
+    (NULL, 1, 1, 326, "andtitle3", "headerimgdir3", "andcontent3", '2023-08-18 11:15:00', 4, null, null, null, null, null, now(), now(), 15, 25, 0, 0, false),
+    (NULL, 4, 8, 329, "andtitle4", "headerimgdir4", "andcontent4", '2023-08-19 12:00:00', 5, null, null, null, null, null, now(), now(), 12, 18, 1, 0, false),
+    (NULL, 5, 3, 332, "andtitle5", "headerimgdir5", "andcontent5", '2023-08-20 13:30:00', 2, null, null, null, null, null, now(), now(), 20, 22, 0, 0, false),
+    (NULL, 1, 9, 335, "andtitle6", "headerimgdir6", "andcontent6", '2023-08-21 14:45:00', 3, null, null, null, null, null, now(), now(), 18, 30, 1, 0, false),
+    (NULL, 7, 1, 338, "andtitle7", "headerimgdir7", "andcontent7", '2023-08-22 15:20:00', 4, null, null, null, null, null, now(), now(), 25, 28, 0, 0, false),
+    (NULL, 8, 6, 341, "andtitle8", "headerimgdir8", "andcontent8", '2023-08-23 16:10:00', 5, null, null, null, null, null, now(), now(), 30, 32, 1, 0, false),
+    (NULL, 2, 7, 344, "andtitle9", "headerimgdir9", "andcontent9", '2023-08-24 17:00:00', 2, null, null, null, null, null, now(), now(), 22, 26, 0, 0, false),
+    (NULL, 3, 10, 347, "andtitle10", "headerimgdir10", "andcontent10", '2023-08-25 18:30:00', 3, null, null, null, null, null, now(), now(), 28, 35, 1, 0, false);


### PR DESCRIPTION
1. 
- AndQueryRepository
- AndQueryRepositoryTest
- AndQueryService
=> 구현 완료 
(AndQueryServiceTest는 추후 컨트롤러 작성하면서 메서드 일부 수정 후 테스트 예정)

2. 
- And 엔티티의 adId, crowdId nullable로 변경
- andLikeCount, andViewCount, andStatus 디폴트값 설정

3. 
- And 관련 Mapper에 CREATE TABLE IF NOT EXIST, INSERT IGNORE 추가