### PR TITLE
Feature/186 : 크라우드 인기 게시물 API / 펀딩 <-> 모임 자동 연계 추가

### DIFF
--- a/andcrowd/src/main/java/com/fiveis/andcrowd/controller/crowd/CrowdController.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/controller/crowd/CrowdController.java
@@ -104,4 +104,10 @@ public class CrowdController {
         crowdService.updateStatus(crowdId, status.get("status"));
     }
 
+    @GetMapping(value = "/popular/top5")
+    public ResponseEntity<List<CrowdDTO.FindById>> findByViewCountAndLikeSum() {
+        List<CrowdDTO.FindById> popularList = crowdService.findByViewCountAndLikeSum();
+        return ResponseEntity.ok(popularList);
+    }
+
 }

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndJPARepository.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/repository/and/AndJPARepository.java
@@ -40,4 +40,8 @@ public interface AndJPARepository extends JpaRepository<And, Integer>, AndQueryR
     @Modifying
     @Query("UPDATE And a SET a.needNumMem = :needNumMem WHERE a.andId = :andId")
     void updateNeedNumMem(@Param("andId") int andId, @Param("needNumMem") int needNumMem);
+
+    @Modifying
+    @Query("UPDATE And a SET a.crowdId = :crowdId WHERE a.andId = :andId")
+    void updateCrowdId(@Param("andId") int andId, @Param("crowdId") int crowdId);
 }

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/repository/crowd/CrowdJPARepository.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/repository/crowd/CrowdJPARepository.java
@@ -6,10 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -38,4 +38,7 @@ public interface CrowdJPARepository extends JpaRepository<Crowd, Integer>, JpaSp
     @Query("SELECT c FROM Crowd c WHERE c.crowdStatus = 1 ORDER BY (c.viewCount + c.likeSum) DESC")
     List<Crowd> findByViewCountAndLikeSum();
 
+    @Modifying
+    @Query("UPDATE Crowd c SET c.andId = :andId WHERE c.crowdId = :crowdId")
+    void updateAndId(@Param("crowdId") int crowdId, @Param("andId") int andId);
 }

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/repository/crowd/CrowdJPARepository.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/repository/crowd/CrowdJPARepository.java
@@ -35,4 +35,7 @@ public interface CrowdJPARepository extends JpaRepository<Crowd, Integer>, JpaSp
     @Query("UPDATE Crowd c SET c.likeSum = c.likeSum - 1 WHERE c.crowdId = :crowdId")
     void decreaseLike(@Param("crowdId") Integer crowdId);
 
+    @Query("SELECT c FROM Crowd c WHERE c.crowdStatus = 1 ORDER BY (c.viewCount + c.likeSum) DESC")
+    List<Crowd> findByViewCountAndLikeSum();
+
 }

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndServiceImpl.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/and/AndServiceImpl.java
@@ -9,14 +9,13 @@ import com.fiveis.andcrowd.entity.user.DynamicUserAnd;
 import com.fiveis.andcrowd.entity.user.DynamicUserFollow;
 import com.fiveis.andcrowd.entity.user.DynamicUserLike;
 import com.fiveis.andcrowd.entity.user.DynamicUserMaker;
-import com.fiveis.andcrowd.entity.user.User;
 import com.fiveis.andcrowd.repository.and.*;
+import com.fiveis.andcrowd.repository.crowd.CrowdJPARepository;
 import com.fiveis.andcrowd.repository.user.DynamicUserAndRepository;
 import com.fiveis.andcrowd.repository.user.DynamicUserMakerRepository;
 import com.fiveis.andcrowd.repository.user.UserJPARepository;
 import com.fiveis.andcrowd.service.user.DynamicUserFollowService;
 import com.fiveis.andcrowd.service.user.DynamicUserLikeService;
-import com.fiveis.andcrowd.service.user.DynamicUserLikeServiceImpl;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -48,6 +47,7 @@ public class AndServiceImpl implements AndService{
     private final DynamicUserFollowService dynamicUserFollowService;
     private final DynamicUserMakerRepository dynamicUserMakerRepository;
     private final JPAQueryFactory query;
+    private final CrowdJPARepository crowdJPARepository;
 
 
     @Autowired
@@ -63,8 +63,8 @@ public class AndServiceImpl implements AndService{
                           DynamicUserLikeService dynamicUserLikeService,
                           DynamicUserFollowService dynamicUserFollowService,
                           DynamicUserMakerRepository dynamicUserMakerRepository,
-                          EntityManager em
-                          ){
+                          EntityManager em,
+                          CrowdJPARepository crowdJPARepository){
         this.andJPARepository = andJPARepository;
         this.andDynamicRepository = andDynamicRepository;
         this.dynamicAndQnaRepository = dynamicAndQnaRepository;
@@ -78,6 +78,7 @@ public class AndServiceImpl implements AndService{
         this.dynamicUserFollowService = dynamicUserFollowService;
         this.dynamicUserMakerRepository = dynamicUserMakerRepository;
         this.query = new JPAQueryFactory(em);
+        this.crowdJPARepository = crowdJPARepository;
     }
 
 
@@ -186,9 +187,14 @@ public class AndServiceImpl implements AndService{
         if (optionalAnd.isPresent()) {
             And updatedAnd = optionalAnd.get();
             updatedAnd.setAndStatus(andStatus);
-
             // 변경된 And 객체를 다시 저장
             andJPARepository.save(updatedAnd);
+
+            // 크라우드에도 연계된 andId 저장
+            int crowdId = updatedAnd.getCrowdId();
+            if(crowdId != 0){
+                crowdJPARepository.updateAndId(crowdId, andId);
+            }
         }
     }
 

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/crowd/CrowdService.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/crowd/CrowdService.java
@@ -30,4 +30,6 @@ public interface CrowdService {
 
     Page<CrowdDTO.FindById> searchPageList(Integer crowdStatus, String sortField, Integer pageNumber, Integer crowdCategoryId, String keyword, Pageable pageable);
 
+    List<CrowdDTO.FindById> findByViewCountAndLikeSum();
+
 }

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/crowd/CrowdServiceImpl.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/crowd/CrowdServiceImpl.java
@@ -5,6 +5,7 @@ import com.fiveis.andcrowd.dto.user.DynamicUserLikeDTO;
 import com.fiveis.andcrowd.entity.crowd.Crowd;
 import com.fiveis.andcrowd.entity.user.DynamicUserMaker;
 import com.fiveis.andcrowd.entity.user.DynamicUserLike;
+import com.fiveis.andcrowd.repository.and.AndJPARepository;
 import com.fiveis.andcrowd.repository.crowd.*;
 import com.fiveis.andcrowd.repository.user.DynamicUserMakerRepository;
 import com.fiveis.andcrowd.repository.user.UserJPARepository;
@@ -42,6 +43,7 @@ public class CrowdServiceImpl implements CrowdService {
     private final UserJPARepository userJPARepository;
     private final DynamicUserMakerRepository dynamicUserMakerRepository;
     private final DynamicUserLikeService dynamicUserLikeService;
+    private final AndJPARepository andJPARepository;
 
     @Override
     public Optional<CrowdDTO.FindById> findByCrowdId(int crowdId) {
@@ -155,9 +157,13 @@ public class CrowdServiceImpl implements CrowdService {
         Optional<Crowd> optionalCrowd = crowdJPARepository.findById(crowdId);
         if (optionalCrowd.isPresent()) {
             Crowd updatedCrowd = optionalCrowd.get();
-
             // 변경된 Crowd 객체를 다시 저장
             crowdJPARepository.save(updatedCrowd.updateCrowdStatus(crowdStatus));
+
+            int andId = updatedCrowd.getAndId();
+            if(andId != 0){
+                andJPARepository.updateCrowdId(andId, crowdId);
+            }
         }
     }
 

--- a/andcrowd/src/main/java/com/fiveis/andcrowd/service/crowd/CrowdServiceImpl.java
+++ b/andcrowd/src/main/java/com/fiveis/andcrowd/service/crowd/CrowdServiceImpl.java
@@ -201,4 +201,20 @@ public class CrowdServiceImpl implements CrowdService {
         return pageList;
     }
 
+    @Override
+    public List<CrowdDTO.FindById> findByViewCountAndLikeSum() {
+        List<Crowd> crowdList = crowdJPARepository.findByViewCountAndLikeSum();
+        List<CrowdDTO.FindById> dtoList = new ArrayList<>();
+
+        int limit = Math.min(crowdList.size(), 5); // 결과 리스트 크기와 5 중 작은 값을 선택
+
+        for (int i = 0; i < limit; i++) {
+            Crowd crowd = crowdList.get(i);
+            CrowdDTO.FindById result = convertToCrowdFindDTO(crowd);
+            dtoList.add(result);
+        }
+
+        return dtoList;
+    }
+
 }


### PR DESCRIPTION
크라우드 인기 게시물 API
- 크라우드 배너에 들어갈 인기 게시물 데이터 가져오는 메서드
- 인기 게시물: 조회수 + 좋아요수가 가장 높은 5개

펀딩 <-> 모임 자동 연계
- 펀딩에서 모임을 연계로 설정시, 해당 펀딩글의 심사가 완료되어 모집중으로 전환되면 모임 테이블에서도 펀딩글의 ID를 받아 crowdId 컬럼을 update (반대도 동일)